### PR TITLE
fix: use current year instead of hard coded 2024

### DIFF
--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -3,7 +3,7 @@ import './globals.css'
 
 const Footer = () => (
   <footer className="w-full bg-custom-pink text-center py-4">
-    © 2024 TOMORoLL. All rights reserved.
+    © {new Date().getFullYear()} TOMORoLL. All rights reserved.
   </footer>
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - The footer now automatically displays the current year, ensuring it stays up to date without manual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->